### PR TITLE
[Bugfix] - Corrigindo duplicação de registros

### DIFF
--- a/adapters/db/product.go
+++ b/adapters/db/product.go
@@ -29,7 +29,7 @@ func (p *ProductDb) Get(id string) (application.ProductInterface, error) {
 
 func (p *ProductDb) Save(product application.ProductInterface) (application.ProductInterface, error) {
 	var rows int
-	p.db.QueryRow("Select id from products where id=?", product.GetID()).Scan(&rows)
+	p.db.QueryRow("Select count(*) from products where id=?", product.GetID()).Scan(&rows)
 	if rows == 0 {
 		_, err := p.create(product)
 		if err != nil {


### PR DESCRIPTION
O `select` retornava o `ID` de um produto, logo, por se tratar do `ID` o retorno não poderia ser atribuído para a variável `rows` por ser um tipo inteiro, com isso o valor de `rows` sempre ficava como 0 e então o código realizava a criação duplicada do produto somente com o status modificado de `disabled` para `enabled`.

A mudança de `ID` para `count(*)` no `select` faz com que o retorno da consulta seja um valor do tipo inteiro e com isso seja possível atribuí-lo à variável `rows` e o código ter o comportamento esperado.