### PR TITLE
Switch to standalone cobra-cli dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.16
 WORKDIR /go/src
 ENV PATH="/go/bin:${PATH}"
 
-RUN go install github.com/spf13/cobra/cobra@latest && \
+RUN go install github.com/spf13/cobra-cli@latest && \
     go install github.com/golang/mock/mockgen@v1.5.0
 
 RUN apt-get update && apt-get install sqlite3 -y


### PR DESCRIPTION
Switches to use the extracted cobra-cli command since it is being removed from the github.com/spf13/cobra module (xref https://github.com/spf13/cobra/issues/1597)