### PR TITLE
Update Dockerfile, update golang version to 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM golang:1.17
 
 WORKDIR /go/src
 ENV PATH="/go/bin:${PATH}"


### PR DESCRIPTION
sqlite3 não estava funcionado com a versão 1.16.

(sqlite3_opt_serialize.go -> go 1.16: erro com a variável Int math.MaxInt. Com a versão go 1.17: Int math.MaxInt64, funcionou tudo ok!).